### PR TITLE
gx: update go-cid

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.0.12: QmWURzU3XRY4wYBsu2LHukKKHp5skkYB1K357nzpbEvRY4
+0.0.13: QmNxamk8jB6saNF5G37Tiipf2JEnxt7qvesbngPMe24wMS

--- a/package.json
+++ b/package.json
@@ -9,33 +9,33 @@
   "gxDependencies": [
     {
       "author": "hsanjuan",
-      "hash": "QmRNFh4wm6FgTDrtsWmnvEP9NTuEa3Ykf72y1LXCyevbGW",
+      "hash": "QmYir8arYJK1RMzDBZU1dqscLorWvthWU8aStL4xhxdYeT",
       "name": "go-ipfs-blockstore",
-      "version": "0.0.14"
+      "version": "0.0.15"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmYVNvtQkeZ6AKSwDrjQTs432QtL6umrrK41EBq3cu7iSP",
+      "hash": "Qmdu2AYUV7yMoVBQPxXNfe7FJcdx16kYtsx6jAPKWQYF1y",
       "name": "go-cid",
-      "version": "0.7.22"
+      "version": "0.7.24"
     },
     {
       "author": "hsanjuan",
-      "hash": "Qmc2faLf7URkHpsbfYM4EMbr8iSAcGAe8VPgVi64HVnwji",
+      "hash": "QmP7gXvwCi5j8sCC3mcuUqvMU2PBMiw2jwQS22Cuxzgov5",
       "name": "go-ipfs-exchange-interface",
-      "version": "0.0.3"
+      "version": "0.0.4"
     },
     {
       "author": "stebalien",
-      "hash": "QmVzK524a2VWLqyvtBeiHKsUAWYgeAk4DBeZoY7vpNPNRx",
+      "hash": "QmZXvzTJTiN6p469osBUtEwm4WwhXXoWcHC8aTS1cAJkjy",
       "name": "go-block-format",
-      "version": "0.1.8"
+      "version": "0.1.9"
     },
     {
       "author": "hsanjuan",
-      "hash": "QmYqPGpZ9Yemr55xus9DiEztkns6Jti5XJ7hC94JbvkdqZ",
+      "hash": "QmdhiCdTZvbeAFvo9XGZfJKZTxwqJCxGwvcaNM5MbPSh15",
       "name": "go-ipfs-blocksutil",
-      "version": "0.0.3"
+      "version": "0.0.4"
     }
   ],
   "gxVersion": "0.12.1",
@@ -43,6 +43,6 @@
   "license": "MIT",
   "name": "go-ipfs-exchange-offline",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.0.12"
+  "version": "0.0.13"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-libp2p-kad-dht/pull/186
- https://github.com/ipfs/go-ipld-git/pull/22
- https://github.com/ipfs/go-ipfs-chunker/pull/2


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace